### PR TITLE
Fix typo in email subject

### DIFF
--- a/webhook.php
+++ b/webhook.php
@@ -24,7 +24,7 @@ try {
 	$webhook = new \shgysk8zer0\Core\GitHubWebhook(CONFIG);
 	$email = new \shgysk8zer0\Core\Email(
 		$_SERVER['SERVER_ADMIN'],
-		sprintf('% event on %s', $webhook->event, $_SERVER['SERVER_NAME'])
+		sprintf('%s event on %s', $webhook->event, $_SERVER['SERVER_NAME'])
 	);
 
 	if ($webhook->validate()) {


### PR DESCRIPTION
## Fix setting subject in WebHook email. Fixes #52
### List of significant changes made
-  Fix typo when settings subject
