### PR TITLE
Redirect logged-in non-subscribers to registration

### DIFF
--- a/single.php
+++ b/single.php
@@ -263,7 +263,9 @@
 	}
 } else {
 	//To redirect to membership level
-	header('Location: ' . wp_login_url(get_permalink()));
+	// /wp-login.php?action=register
+
+	header('Location: ' .  wp_registration_url());
 }
 if (DEBUG_MODE) {
 		$console->log("Loaded in {$timer} ms.");


### PR DESCRIPTION
## Redirect logged-in non-subscribers to registration. Fixes #68
### List of significant changes made
-  Redirect to `wp_registration_url()` instead of `wp_login_url(get_permalink())`
